### PR TITLE
Split out WebSocket event types

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,9 +300,7 @@ interface RadarCandle extends Ohlc {
   startBlockTimestamp: number;
   endBlock: number; // the last block included in this candle (inclusive)
   endBlockTimestamp: number;
-  baseTokenAddress: string;
   baseTokenVolume: BigNumber;
-  quoteTokenAddress: string;
   quoteTokenVolume: BigNumber;
 }
 ```
@@ -361,7 +359,8 @@ interface WebsocketEvent {
 
 ### RadarFill
 ```javascript
-interface RadarFill extends MarketEvent, OrderEvent, OnChainEvent {
+interface RadarFill extends MarketEvent, OnChainEvent {
+  type: UserOrderType;
   blockNumber: number;
   maker: string;
   taker: string;

--- a/README.md
+++ b/README.md
@@ -308,13 +308,22 @@ interface RadarCandle extends Ohlc {
 ```
 
 ## Radar Websocket Events
-Radar Events utilized by the Websocket Endpoint.
 
-### RadarEvent
+### MarketEvent
+An event tied to a market (base/quote).
+
 ```javascript
-interface RadarEvent {
+interface MarketEvent {
   baseTokenAddress: string;
   quoteTokenAddress: string;
+}
+```
+
+### OrderEvent
+An event containing a RadarSignedOrder.
+
+```javascript
+interface OrderEvent {
   order: RadarSignedOrder;
 }
 ```
@@ -328,15 +337,15 @@ interface OnChainEvent {
 }
 ```
 
-### Order Events
+### Book Events
 ```javascript
-interface RadarNewOrder extends RadarEvent { }
+interface RadarNewOrder extends MarketEvent, OrderEvent { }
 
-interface RadarRemoveOrder extends RadarEvent {
+interface RadarRemoveOrder extends MarketEvent {
   reason: string;
 }
 
-interface RadarCancelOrder extends OnChainEvent {
+interface RadarCancelOrder extends MarketEvent, OnChainEvent {
   orderType: RadarOrderType;
   orderHash: string;
 }
@@ -352,7 +361,7 @@ interface WebsocketEvent {
 
 ### RadarFill
 ```javascript
-interface RadarFill extends RadarEvent, OnChainEvent {
+interface RadarFill extends MarketEvent, OrderEvent, OnChainEvent {
   blockNumber: number;
   maker: string;
   taker: string;

--- a/README.md
+++ b/README.md
@@ -371,6 +371,7 @@ interface RadarFill extends MarketEvent, OnChainEvent {
   filledQuoteTokenAmount: BigNumber; // converted
   orderHash: string;
   timestamp: number;
+  outlier: boolean; // Whether or not the fill is an outlier
 }
 ```
 

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -187,9 +187,7 @@ export interface RadarCandle extends Ohlc {
     startBlockTimestamp: number;
     endBlock: number;
     endBlockTimestamp: number;
-    baseTokenAddress: string;
     baseTokenVolume: BigNumber;
-    quoteTokenAddress: string;
     quoteTokenVolume: BigNumber;
 }
 /**
@@ -239,7 +237,8 @@ export interface WebsocketEvent {
 /**
  * Fill Event
  */
-export interface RadarFill extends MarketEvent, OrderEvent, OnChainEvent {
+export interface RadarFill extends MarketEvent, OnChainEvent {
+    type: UserOrderType;
     blockNumber: number;
     maker: string;
     taker: string;

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -249,6 +249,7 @@ export interface RadarFill extends MarketEvent, OnChainEvent {
     filledQuoteTokenAmount: BigNumber;
     orderHash: string;
     timestamp: number;
+    outlier: boolean;
 }
 /**
  * WebSocket Request

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -193,11 +193,16 @@ export interface RadarCandle extends Ohlc {
     quoteTokenVolume: BigNumber;
 }
 /**
- * Radar Events utilized by the Websocket Endpoint.
+ * An event tied to a market (base/quote)
  */
-export interface RadarEvent {
+export interface MarketEvent {
     baseTokenAddress: string;
     quoteTokenAddress: string;
+}
+/**
+ * An event containing a RadarSignedOrder.
+ */
+export interface OrderEvent {
     order: RadarSignedOrder;
 }
 /**
@@ -209,19 +214,19 @@ export interface OnChainEvent {
 /**
  * New Order Event
  */
-export interface RadarNewOrder extends RadarEvent {
+export interface RadarNewOrder extends MarketEvent, OrderEvent {
 }
 /**
  * Canceled Order Event
  */
-export interface RadarCancelOrder extends OnChainEvent {
+export interface RadarCancelOrder extends MarketEvent, OnChainEvent {
     orderType: RadarOrderType;
     orderHash: string;
 }
 /**
  * Remove Order Event
  */
-export interface RadarRemoveOrder extends RadarEvent {
+export interface RadarRemoveOrder extends MarketEvent {
     reason: string;
 }
 /**
@@ -234,7 +239,7 @@ export interface WebsocketEvent {
 /**
  * Fill Event
  */
-export interface RadarFill extends RadarEvent, OnChainEvent {
+export interface RadarFill extends MarketEvent, OrderEvent, OnChainEvent {
     blockNumber: number;
     maker: string;
     taker: string;

--- a/index.ts
+++ b/index.ts
@@ -215,11 +215,17 @@ export interface RadarCandle extends Ohlc {
 }
 
 /**
- * Radar Events utilized by the Websocket Endpoint.
+ * An event tied to a market (base/quote)
  */
-export interface RadarEvent {
+export interface MarketEvent {
   baseTokenAddress: string;
   quoteTokenAddress: string;
+}
+
+/**
+ * An event containing a RadarSignedOrder.
+ */
+export interface OrderEvent {
   order: RadarSignedOrder;
 }
 
@@ -233,13 +239,13 @@ export interface OnChainEvent {
 /**
  * New Order Event
  */
-export interface RadarNewOrder extends RadarEvent {
+export interface RadarNewOrder extends MarketEvent, OrderEvent {
 }
 
 /**
  * Canceled Order Event
  */
-export interface RadarCancelOrder extends OnChainEvent {
+export interface RadarCancelOrder extends MarketEvent, OnChainEvent {
   orderType: RadarOrderType;
   orderHash: string;
 }
@@ -247,7 +253,7 @@ export interface RadarCancelOrder extends OnChainEvent {
 /**
  * Remove Order Event
  */
-export interface RadarRemoveOrder extends RadarEvent {
+export interface RadarRemoveOrder extends MarketEvent {
   reason: string;
 }
 
@@ -262,7 +268,7 @@ export interface WebsocketEvent {
 /**
  * Fill Event
  */
-export interface RadarFill extends RadarEvent, OnChainEvent {
+export interface RadarFill extends MarketEvent, OrderEvent, OnChainEvent {
   blockNumber: number;
   maker: string;
   taker: string;

--- a/index.ts
+++ b/index.ts
@@ -208,9 +208,7 @@ export interface RadarCandle extends Ohlc {
   startBlockTimestamp: number;
   endBlock: number; // the last block included in this candle (inclusive)
   endBlockTimestamp: number;
-  baseTokenAddress: string;
   baseTokenVolume: BigNumber;
-  quoteTokenAddress: string;
   quoteTokenVolume: BigNumber;
 }
 
@@ -268,7 +266,8 @@ export interface WebsocketEvent {
 /**
  * Fill Event
  */
-export interface RadarFill extends MarketEvent, OrderEvent, OnChainEvent {
+export interface RadarFill extends MarketEvent, OnChainEvent {
+  type: UserOrderType;
   blockNumber: number;
   maker: string;
   taker: string;

--- a/index.ts
+++ b/index.ts
@@ -278,6 +278,7 @@ export interface RadarFill extends MarketEvent, OnChainEvent {
   filledQuoteTokenAmount: BigNumber; // converted
   orderHash: string;
   timestamp: number;
+  outlier: boolean; // Whether or not the fill is an outlier
 }
 
 /**


### PR DESCRIPTION
This PR contains the following changes:

* Split out the extended WebSocket event interfaces for increased flexibility
* Field addition/removal to `RadarFill`, `RadarRemoveOrder`, `RadarCancelOrder`, and `RadarCandle`