### PR TITLE
Update UnsignedOrder interface, Remove v1 language

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ interface UnsignedOrder {
   makerAssetData: string;
   takerAssetData: string;
   salt: BigNumber;
-  exchangeAddress: 'SET';
+  exchangeAddress: string;
   feeRecipientAddress: string;
   expirationTimeSeconds: BigNumber;
   signature: 'SET';

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ interface UnsignedOrder {
   makerAssetData: string;
   takerAssetData: string;
   salt: BigNumber;
-  exchangeAddress: string;
+  exchangeAddress: 'SET';
   feeRecipientAddress: string;
   expirationTimeSeconds: BigNumber;
   signature: 'SET';

--- a/README.md
+++ b/README.md
@@ -222,18 +222,20 @@ An unsigned order at the specified quantity and price.
 
 ```javascript
 interface UnsignedOrder {
-  maker: 'SET';
-  taker: string;
+  senderAddress: 'SET';
+  makerAddress: 'SET';
+  takerAddress: string;
   makerFee: BigNumber;
   takerFee: BigNumber;
-  makerTokenAmount: BigNumber;
-  takerTokenAmount: BigNumber;
-  makerTokenAddress: string;
-  takerTokenAddress: string;
+  makerAssetAmount: BigNumber;
+  takerAssetAmount: BigNumber;
+  makerAssetData: string;
+  takerAssetData: string;
   salt: BigNumber;
-  exchangeContractAddress: 'SET';
-  feeRecipient: string;
-  expirationUnixTimestampSec: 'SET';
+  exchangeAddress: string;
+  feeRecipientAddress: string;
+  expirationTimeSeconds: BigNumber;
+  signature: 'SET';
 }
 ```
 
@@ -267,7 +269,7 @@ Fee information for a given market.
 interface RadarOrderFeeResponse {
   makerFee: BigNumber;
   takerFee: BigNumber;
-  feeRecipient: string;
+  feeRecipientAddress: string;
   gasEstimate?: BigNumber;
  }
 ```
@@ -312,11 +314,11 @@ A fill without the RadarSignedOrder information.
 interface RadarFill extends MarketEvent, OnChainEvent {
   type: UserOrderType;
   blockNumber: number;
-  maker: string;
-  taker: string;
-  feeRecipient: string;
-  paidMakerFee: BigNumber; // converted
-  paidTakerFee: BigNumber; // converted
+  makerAddress: string;
+  takerAddress: string;
+  feeRecipientAddress: string;
+  makerFeePaid: BigNumber; // converted
+  takerFeePaid: BigNumber; // converted
   filledBaseTokenAmount: BigNumber; // converted
   filledQuoteTokenAmount: BigNumber; // converted
   orderHash: string;

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -125,18 +125,20 @@ export interface RadarLimitOrder {
  * An unsigned order at the specified quantity and price
  */
 export interface UnsignedOrder {
-    maker: 'SET';
-    taker: string;
+    senderAddress: 'SET';
+    makerAddress: 'SET';
+    takerAddress: string;
     makerFee: BigNumber;
     takerFee: BigNumber;
-    makerTokenAmount: BigNumber;
-    takerTokenAmount: BigNumber;
-    makerTokenAddress: string;
-    takerTokenAddress: string;
+    makerAssetAmount: BigNumber;
+    takerAssetAmount: BigNumber;
+    makerAssetData: string;
+    takerAssetData: string;
     salt: BigNumber;
-    exchangeContractAddress: 'SET';
-    feeRecipient: string;
-    expirationUnixTimestampSec: 'SET';
+    exchangeAddress: string;
+    feeRecipientAddress: string;
+    expirationTimeSeconds: BigNumber;
+    signature: 'SET';
 }
 /**
  * A request for fillable orders, up to the specified quantity, at the best price.
@@ -161,7 +163,7 @@ export interface RadarMarketOrderResponse {
 export interface RadarOrderFeeResponse {
     makerFee: BigNumber;
     takerFee: BigNumber;
-    feeRecipient: string;
+    feeRecipientAddress: string;
     gasEstimate?: BigNumber;
 }
 /**
@@ -199,11 +201,11 @@ export interface RadarCandle extends Ohlc {
 export interface RadarFill extends MarketEvent, OnChainEvent {
     type: UserOrderType;
     blockNumber: number;
-    maker: string;
-    taker: string;
-    feeRecipient: string;
-    paidMakerFee: BigNumber;
-    paidTakerFee: BigNumber;
+    makerAddress: string;
+    takerAddress: string;
+    feeRecipientAddress: string;
+    makerFeePaid: BigNumber;
+    takerFeePaid: BigNumber;
     filledBaseTokenAmount: BigNumber;
     filledQuoteTokenAmount: BigNumber;
     orderHash: string;

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -135,7 +135,7 @@ export interface UnsignedOrder {
     makerAssetData: string;
     takerAssetData: string;
     salt: BigNumber;
-    exchangeAddress: 'SET';
+    exchangeAddress: string;
     feeRecipientAddress: string;
     expirationTimeSeconds: BigNumber;
     signature: 'SET';

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -135,7 +135,7 @@ export interface UnsignedOrder {
     makerAssetData: string;
     takerAssetData: string;
     salt: BigNumber;
-    exchangeAddress: string;
+    exchangeAddress: 'SET';
     feeRecipientAddress: string;
     expirationTimeSeconds: BigNumber;
     signature: 'SET';

--- a/index.ts
+++ b/index.ts
@@ -140,18 +140,20 @@ export interface RadarLimitOrder {
  * An unsigned order at the specified quantity and price
  */
 export interface UnsignedOrder {
-  maker: 'SET';
-  taker: string;
+  senderAddress: 'SET';
+  makerAddress: 'SET';
+  takerAddress: string;
   makerFee: BigNumber;
   takerFee: BigNumber;
-  makerTokenAmount: BigNumber;
-  takerTokenAmount: BigNumber;
-  makerTokenAddress: string;
-  takerTokenAddress: string;
+  makerAssetAmount: BigNumber;
+  takerAssetAmount: BigNumber;
+  makerAssetData: string;
+  takerAssetData: string;
   salt: BigNumber;
-  exchangeContractAddress: 'SET';
-  feeRecipient: string;
-  expirationUnixTimestampSec: 'SET';
+  exchangeAddress: string;
+  feeRecipientAddress: string;
+  expirationTimeSeconds: BigNumber;
+  signature: 'SET';
 }
 
 /**
@@ -179,7 +181,7 @@ export interface RadarMarketOrderResponse {
 export interface RadarOrderFeeResponse {
   makerFee: BigNumber;
   takerFee: BigNumber;
-  feeRecipient: string;
+  feeRecipientAddress: string;
   gasEstimate?: BigNumber;
 }
 
@@ -221,11 +223,11 @@ export interface RadarCandle extends Ohlc {
 export interface RadarFill extends MarketEvent, OnChainEvent {
   type: UserOrderType;
   blockNumber: number;
-  maker: string;
-  taker: string;
-  feeRecipient: string;
-  paidMakerFee: BigNumber; // converted
-  paidTakerFee: BigNumber; // converted
+  makerAddress: string;
+  takerAddress: string;
+  feeRecipientAddress: string;
+  makerFeePaid: BigNumber; // converted
+  takerFeePaid: BigNumber; // converted
   filledBaseTokenAmount: BigNumber; // converted
   filledQuoteTokenAmount: BigNumber; // converted
   orderHash: string;

--- a/index.ts
+++ b/index.ts
@@ -150,7 +150,7 @@ export interface UnsignedOrder {
   makerAssetData: string;
   takerAssetData: string;
   salt: BigNumber;
-  exchangeAddress: 'SET';
+  exchangeAddress: string;
   feeRecipientAddress: string;
   expirationTimeSeconds: BigNumber;
   signature: 'SET';

--- a/index.ts
+++ b/index.ts
@@ -150,7 +150,7 @@ export interface UnsignedOrder {
   makerAssetData: string;
   takerAssetData: string;
   salt: BigNumber;
-  exchangeAddress: string;
+  exchangeAddress: 'SET';
   feeRecipientAddress: string;
   expirationTimeSeconds: BigNumber;
   signature: 'SET';


### PR DESCRIPTION
This PR updates the `UnsignedOrder` interface & updates interface member names to v2.