### PR TITLE
Standardize on Cancelled over Canceled

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Various order states used by Radar.
 enum RadarOrderState {
   OPEN = 'OPEN',
   FILLED = 'FILLED',
-  CANCELED = 'CANCELED',
+  CANCELLED = 'CANCELLED',
   EXPIRED = 'EXPIRED',
   UNFUNDED = 'UNFUNDED'
 }

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -12,7 +12,7 @@ export declare enum RadarOrderType {
 export declare enum RadarOrderState {
     OPEN = "OPEN",
     FILLED = "FILLED",
-    CANCELED = "CANCELED",
+    CANCELLED = "CANCELLED",
     EXPIRED = "EXPIRED",
     UNFUNDED = "UNFUNDED",
 }
@@ -237,7 +237,7 @@ export interface OnChainEvent {
 export interface RadarNewOrder extends MarketEvent, OrderEvent {
 }
 /**
- * Canceled Order Event
+ * Cancelled Order Event
  */
 export interface RadarCancelOrder extends MarketEvent, OnChainEvent {
     orderType: RadarOrderType;

--- a/dist/index.js
+++ b/dist/index.js
@@ -14,7 +14,7 @@ var RadarOrderState;
 (function (RadarOrderState) {
     RadarOrderState["OPEN"] = "OPEN";
     RadarOrderState["FILLED"] = "FILLED";
-    RadarOrderState["CANCELED"] = "CANCELED";
+    RadarOrderState["CANCELLED"] = "CANCELLED";
     RadarOrderState["EXPIRED"] = "EXPIRED";
     RadarOrderState["UNFUNDED"] = "UNFUNDED";
 })(RadarOrderState = exports.RadarOrderState || (exports.RadarOrderState = {}));

--- a/index.ts
+++ b/index.ts
@@ -15,7 +15,7 @@ export enum RadarOrderType {
 export enum RadarOrderState {
   OPEN = 'OPEN',
   FILLED = 'FILLED',
-  CANCELED = 'CANCELED',
+  CANCELLED = 'CANCELLED',
   EXPIRED = 'EXPIRED',
   UNFUNDED = 'UNFUNDED'
 }
@@ -264,7 +264,7 @@ export interface RadarNewOrder extends MarketEvent, OrderEvent {
 }
 
 /**
- * Canceled Order Event
+ * Cancelled Order Event
  */
 export interface RadarCancelOrder extends MarketEvent, OnChainEvent {
   orderType: RadarOrderType;


### PR DESCRIPTION
Follow the 0x standard spelling for `Cancelled` to prevent future confusion and bugs.